### PR TITLE
Don't allow selecting cookie in cookie clicker

### DIFF
--- a/src/components/CookieClicker.vue
+++ b/src/components/CookieClicker.vue
@@ -19,6 +19,7 @@
     font-size: 9rem;
     cursor: pointer;
     transition: font-size .2s;
+    user-select: none;
   }
 
   .cookie:hover {


### PR DESCRIPTION
Currently, it gets highlighted when you click on it. idk HTML or CSS but hopefully adding `user-select: none` to the cookie class should fix that