### PR TITLE
Remove dictionary related api calls from the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vyxal Interpreter</title>
     <script src="https://vyxal.github.io/Vyxal/vyxal.js" async defer></script>
-    <script src="https://vyxal.github.io/Vyxal/dictionary.js" async defer></script>
   </head>
   <body>
     <div id="app"></div>

--- a/src/@types/vyxal.d.ts
+++ b/src/@types/vyxal.d.ts
@@ -29,12 +29,4 @@ declare const Vyxal: {
 
   decompress(text: string): string;
 
-  setShortDict(dict: string[]): void;
-
-  setLongDict(dict: string[]): void;
-};
-
-declare const dictionary: {
-  short: string[];
-  long: string[];
 };

--- a/src/components/TextCompressor.vue
+++ b/src/components/TextCompressor.vue
@@ -38,8 +38,6 @@ export default defineComponent({
   },
   methods: {
     compress() {
-      Vyxal.setShortDict(dictionary.short);
-      Vyxal.setLongDict(dictionary.long);
       this.compressed = Vyxal.compress(this.text);
     },
     copy() {

--- a/src/stores/MainStore.ts
+++ b/src/stores/MainStore.ts
@@ -82,7 +82,6 @@ export const useMainStore = defineStore("main", {
         inputs: this.inputs,
         flags: this.flags,
         session,
-        dictionary,
       });
 
       setTimeout(() => {

--- a/src/worker.js
+++ b/src/worker.js
@@ -7,8 +7,6 @@ self.addEventListener("message", function (e) {
   const sendFn = (x) => {
     this.postMessage({ val: x, command: "append", session: session });
   };
-  Vyxal.setShortDict(data.dictionary.short);
-  Vyxal.setLongDict(data.dictionary.long);
   Vyxal.execute(data.code, data.inputs, data.flags, sendFn);
   this.postMessage({ command: "done", session: data.session });
 });


### PR DESCRIPTION
The JS API was recently changed so that the dictionary no longer has to be set by the site.

Closes #3 