### PR TITLE
bug fix (l flag not working as excepted)

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,7 +105,7 @@ function shareOptions(shareType) {
     const url = generateURL()
     const flags = document.getElementById("flag").value
     let flagAppendage = ""
-    const flagsThatMatter = flags.replace(/[5bBT<]/g, "");
+    const flagsThatMatter = flags.replace(/[5bBT<l]/g, "");
     if (flagsThatMatter) {
         flagAppendage = " `" + flagsThatMatter + "`"
     }


### PR DESCRIPTION
A bug, if I click the "Generate Code Golf Submission", the output would be:


    # [Vyxal 3](https://github.com/Vyxal/Vyxal/tree/version-3) ``, 17 bytes

    ₂ʀ(nkAinꜝ×nꜝkAİ+,

    [Try it Online! (link is to literate version)](https://vyxal.github.io/latest.html#WyJsIiwiIiwidHdlbnR5LXNpeCB6ZXJvLXJhbmdlIGRvLXRvLWVhY2ggbiB1cHBlcmNhc2UtYWxwaGFiZXQgaW5kZXggbiBpbmNyZW1lbnQgc3RyLXJlcGVhdCBuIGluY3JlbWVudCB1cHBlcmNhc2UtYWxwaGFiZXQgxLAgcGx1cyBwcmludCIsIiIsIiIsIjMuNC4xIl0=)

The `` doesn't make any sense. [Source](https://codegolf.stackexchange.com/a/269155/106959)